### PR TITLE
fix: migrate InfluxDB connection config from YAML to UI (HA 2026.3)

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -46,13 +46,9 @@ api:
 #zha_toolkit is now enabled through HACS custom components
 #zha_toolkit:
 
-#enable influxdb integration with all defaults
+# InfluxDB: connection details managed via UI (Settings → Devices & Services → InfluxDB)
+# Removed host/port/database/username/password - migrated to UI in HA 2026.3 (required before 2026.9)
 influxdb:
-  host: a0d7b954-influxdb
-  port: 8086
-  database: homeassistant
-  username: !secret influxdb_homeassistant_username
-  password: !secret influxdb_homeassistant_password
   max_retries: 3
   default_measurement: state
 


### PR DESCRIPTION
Removes InfluxDB connection keys from configuration.yaml. Required before HA 2026.9 when YAML support is dropped. Connection was auto-imported to UI by HA 2026.3. max_retries and default_measurement remain in YAML. After merging, pull on HA and restart core.