### PR TITLE
docs: document uptake workflow (pull → validate → restart)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,14 +18,13 @@ This repository contains a Home Assistant configuration and automation setup.
 
 ## Config Validation
 
-Validate the configuration without restarting Home Assistant:
+**Always validate before restarting HA.** Use the supervisor CLI over SSH:
 
 ```bash
-# Inside the HA container or on the host
-hass --script check_config --config /path/to/config
-
-# Or via the Developer Tools > YAML > Check Configuration in the HA UI
+ssh root@homeassistant.local "ha core check"
 ```
+
+This runs a full config parse without restarting. Exit code 0 = valid. Any errors are printed to stdout. Only restart after a clean check.
 
 ## Key Conventions
 
@@ -135,13 +134,18 @@ After the HA instance pushes UI-driven changes to `master`:
 git pull origin master
 ```
 
-### Deploying Local Changes to HA
+### Deploying Local Changes to HA ("uptake")
 
-After merging a PR:
+After merging a PR, always follow this sequence — **never skip the check step**:
+
 ```bash
-# on HA via SSH
-ssh root@homeassistant.local "cd /config && git pull && ha core restart"
+# 1. Pull latest master
+# 2. Validate config (MUST pass before restart)
+# 3. Restart HA
+ssh root@homeassistant.local "cd /homeassistant && git pull && ha core check && ha core restart"
 ```
+
+If `ha core check` fails, **do not restart** — diagnose and fix the config error first. A failed restart can leave HA in a broken state.
 
 ## Diagnosing Automation Problems
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -152,17 +152,21 @@ If `ha core check` fails, **do not restart** — diagnose and fix the config err
 These rules govern when Copilot should proceed automatically vs. pause and ask the user.
 
 ### Auto-approve (proceed without asking)
-- All SSH read operations: `jq`, `grep`, `ls`, `cat` on HA files; `ha core logs`; `ha addons list/info`; `ha core check`
-- Local git: `status`, `log`, `diff`, `checkout`, `pull`, `branch`, `add`, `commit`, `push` to feature branches
+- All SSH read operations: `jq`, `grep`, `ls`, `cat` on HA files; `ha core logs`; `ha addons list/info`; `ha core check` — use the **ha-investigate skill** so these are wrapped in one approved invocation rather than individual SSH prompts
+- Local git (non-push): `status`, `log`, `diff`, `checkout`, `pull`, `branch`, `add`, `commit`, `fetch`, `merge`, `stash`
 - GitHub: `gh issue create`, `gh pr create`, `gh issue comment`, `gh issue reopen`
 - Local file reads and edits on git-tracked files
 - Web search
 
 ### Always ask the user first
+- **`git push`** (any variant) — always show the full command so the user can spot `--force`, `--force-with-lease`, or `--delete` before it runs. History-rewriting commands (`git reset --hard`, `git commit --amend`, `git push --force`, `git branch -D`) must never be auto-approved. `git rebase` is fine to auto-approve.
 - **Writing to `.storage/` files** on the HA instance — these are live HA config files; corrupt JSON breaks entities and integrations
 - **`ha core restart`** — causes ~60s production downtime
 - **`git pull` on the HA instance** — deploys code to production
 - **`gh issue close`** — closing issues is harder to notice than creating them
+
+### Note on current Copilot CLI limitations
+Copilot CLI `shell()` patterns match at the subcommand level (`git push`) but not argument level (`git push --force`). Until argument-level matching is supported, requiring approval for ALL `git push` is the safest approach — the approval prompt shows the full command so dangerous flags are visible. Track: `shell(git push --force)` deny rule when CLI adds argument matching.
 
 ### Notes
 - `.storage/` contains ALL UI-managed HA config: dashboards, entity registry, device registry, all integration credentials (config entries), helpers, auth. It is NOT just Lovelace.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -147,6 +147,27 @@ ssh root@homeassistant.local "cd /homeassistant && git pull && ha core check && 
 
 If `ha core check` fails, **do not restart** — diagnose and fix the config error first. A failed restart can leave HA in a broken state.
 
+## Tool Permission Policy
+
+These rules govern when Copilot should proceed automatically vs. pause and ask the user.
+
+### Auto-approve (proceed without asking)
+- All SSH read operations: `jq`, `grep`, `ls`, `cat` on HA files; `ha core logs`; `ha addons list/info`; `ha core check`
+- Local git: `status`, `log`, `diff`, `checkout`, `pull`, `branch`, `add`, `commit`, `push` to feature branches
+- GitHub: `gh issue create`, `gh pr create`, `gh issue comment`, `gh issue reopen`
+- Local file reads and edits on git-tracked files
+- Web search
+
+### Always ask the user first
+- **Writing to `.storage/` files** on the HA instance — these are live HA config files; corrupt JSON breaks entities and integrations
+- **`ha core restart`** — causes ~60s production downtime
+- **`git pull` on the HA instance** — deploys code to production
+- **`gh issue close`** — closing issues is harder to notice than creating them
+
+### Notes
+- `.storage/` contains ALL UI-managed HA config: dashboards, entity registry, device registry, all integration credentials (config entries), helpers, auth. It is NOT just Lovelace.
+- When the `ha-deploy` skill exists, use it for the pull→check→restart sequence — it provides guardrails and SSH is always available even if HA core fails to start (SSH addon is a separate supervisor process).
+
 ## Diagnosing Automation Problems
 
 ### Downloading Traces

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -204,7 +204,7 @@ Physical button press
   → Hook blueprint  (maps abstract action → light.turn_off / light.turn_on etc.)
 ```
 
-Controller blueprints live in `/config/blueprints/automation/EPMatt/`:
+Controller blueprints live in `/homeassistant/blueprints/automation/EPMatt/`:
 - `philips_324131092621.yaml` — Philips Hue RWL021 dimmer
 - `ikea_e2001_e2002_new.yaml` — IKEA STYRBAR (E2001/E2002)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -147,30 +147,17 @@ ssh root@homeassistant.local "cd /homeassistant && git pull && ha core check && 
 
 If `ha core check` fails, **do not restart** — diagnose and fix the config error first. A failed restart can leave HA in a broken state.
 
-## Tool Permission Policy
+## Skills
 
-These rules govern when Copilot should proceed automatically vs. pause and ask the user.
+Use these skills instead of raw SSH or shell commands:
 
-### Auto-approve (proceed without asking)
-- All SSH read operations: `jq`, `grep`, `ls`, `cat` on HA files; `ha core logs`; `ha addons list/info`; `ha core check` — use the **ha-investigate skill** so these are wrapped in one approved invocation rather than individual SSH prompts
-- Local git (non-push): `status`, `log`, `diff`, `checkout`, `pull`, `branch`, `add`, `commit`, `fetch`, `merge`, `stash`
-- GitHub: `gh issue create`, `gh pr create`, `gh issue comment`, `gh issue reopen`
-- Local file reads and edits on git-tracked files
-- Web search
+| Task | Skill |
+|------|-------|
+| Deploy after merging a PR (pull → validate → restart) | `ha-deploy` |
+| Inspect HA status, logs, entities, config entries, Lovelace | `ha-investigate` |
+| Diagnose why an automation didn't fire | `analyze-ha-traces` |
 
-### Always ask the user first
-- **`git push`** (any variant) — always show the full command so the user can spot `--force`, `--force-with-lease`, or `--delete` before it runs. History-rewriting commands (`git reset --hard`, `git commit --amend`, `git push --force`, `git branch -D`) must never be auto-approved. `git rebase` is fine to auto-approve.
-- **Writing to `.storage/` files** on the HA instance — these are live HA config files; corrupt JSON breaks entities and integrations
-- **`ha core restart`** — causes ~60s production downtime
-- **`git pull` on the HA instance** — deploys code to production
-- **`gh issue close`** — closing issues is harder to notice than creating them
-
-### Note on current Copilot CLI limitations
-Copilot CLI `shell()` patterns match at the subcommand level (`git push`) but not argument level (`git push --force`). Until argument-level matching is supported, requiring approval for ALL `git push` is the safest approach — the approval prompt shows the full command so dangerous flags are visible. Track: `shell(git push --force)` deny rule when CLI adds argument matching.
-
-### Notes
-- `.storage/` contains ALL UI-managed HA config: dashboards, entity registry, device registry, all integration credentials (config entries), helpers, auth. It is NOT just Lovelace.
-- When the `ha-deploy` skill exists, use it for the pull→check→restart sequence — it provides guardrails and SSH is always available even if HA core fails to start (SSH addon is a separate supervisor process).
+**Note on `.storage/`:** Contains ALL UI-managed HA config — dashboards, entity registry, device registry, all integration credentials, helpers, auth. Never write to `.storage/` files without explicit user confirmation.
 
 ## Diagnosing Automation Problems
 

--- a/.github/skills/ha-deploy/SKILL.md
+++ b/.github/skills/ha-deploy/SKILL.md
@@ -18,6 +18,9 @@ python .github/skills/ha-deploy/deploy.py --check-only
 
 # Restart only (skip pull) — if HA is already on latest but needs a restart
 python .github/skills/ha-deploy/deploy.py --restart-only
+
+# Override SSH target or repo path (or set HA_HOST / HA_REPO_DIR env vars)
+python .github/skills/ha-deploy/deploy.py --host root@192.168.1.x --repo-dir /homeassistant
 ```
 
 ## What it does
@@ -32,7 +35,7 @@ python .github/skills/ha-deploy/deploy.py --restart-only
 
 - **Config check MUST pass** before restart is attempted
 - If HA doesn't come back within 120s, SSH is still available (SSH addon is a separate supervisor process — it survives HA core failures)
-- Rollback: `git revert HEAD --no-edit && ha core check && ha core restart`
+- Rollback: `ssh root@homeassistant.local "cd /homeassistant && git fetch origin && git reset --hard origin/master && ha core check && ha core restart"`
 
 ## When NOT to use this skill
 

--- a/.github/skills/ha-deploy/SKILL.md
+++ b/.github/skills/ha-deploy/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: ha-deploy
+description: Safely deploy latest HA config changes to the Home Assistant instance. Runs git pull → config validation → restart with online polling. Use this whenever the user says "deploy", "uptake", "apply to HA", or after merging a PR that changes configuration.yaml, automations.yaml, scripts.yaml, blueprints, or custom_components.
+---
+
+# ha-deploy: Safe HA Deployment
+
+Use this skill whenever changes need to be applied to the live HA instance. **Never run `ha core restart` directly** — always go through this skill.
+
+## Running the skill
+
+```bash
+# Full deploy: pull + validate + restart
+python .github/skills/ha-deploy/deploy.py
+
+# Validate only (no restart) — useful before merging a PR
+python .github/skills/ha-deploy/deploy.py --check-only
+
+# Restart only (skip pull) — if HA is already on latest but needs a restart
+python .github/skills/ha-deploy/deploy.py --restart-only
+```
+
+## What it does
+
+1. **`git pull`** — pulls latest master onto the HA instance (`/homeassistant`)
+2. **`ha core check`** — validates the full config; aborts if any error
+3. **`ha core restart`** — restarts HA core (~60s downtime)
+4. **Polls for online** — waits up to 120s for HA to report `state: running`
+5. **Rollback instructions** — if HA doesn't recover, prints SSH commands to diagnose and revert
+
+## Guardrails
+
+- **Config check MUST pass** before restart is attempted
+- If HA doesn't come back within 120s, SSH is still available (SSH addon is a separate supervisor process — it survives HA core failures)
+- Rollback: `git revert HEAD --no-edit && ha core check && ha core restart`
+
+## When NOT to use this skill
+
+- Changes to `.storage/` files (Lovelace dashboards, entity registry) — those take effect on next browser refresh or HA restart, but require explicit user approval before touching
+- HACS component installs — those need to be done via the HACS UI, not via git

--- a/.github/skills/ha-deploy/deploy.py
+++ b/.github/skills/ha-deploy/deploy.py
@@ -21,7 +21,7 @@ HA_HOST = os.environ.get("HA_HOST", "root@homeassistant.local")
 HA_REPO_DIR = os.environ.get("HA_REPO_DIR", "/homeassistant")
 RESTART_TIMEOUT = 120  # seconds to wait for HA to come back
 
-SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3"]
+SSH_OPTS = ["-o", "ConnectTimeout=10", "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3"]
 
 
 def ssh(cmd: str) -> subprocess.CompletedProcess:

--- a/.github/skills/ha-deploy/deploy.py
+++ b/.github/skills/ha-deploy/deploy.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+ha-deploy: Pull latest master to HA, validate config, restart if valid.
+
+Usage:
+    python .github/skills/ha-deploy/deploy.py
+    python .github/skills/ha-deploy/deploy.py --check-only   # validate without restart
+    python .github/skills/ha-deploy/deploy.py --restart-only # skip pull, just check+restart
+"""
+import subprocess
+import sys
+import time
+import argparse
+
+HA_HOST = "root@homeassistant.local"
+RESTART_TIMEOUT = 120  # seconds to wait for HA to come back
+
+
+def ssh(cmd: str, capture: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["ssh", HA_HOST, cmd],
+        capture_output=capture,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+
+def step(msg: str):
+    print(f"\n>>> {msg}")
+
+
+def ok(msg: str):
+    print(f"    ✅ {msg}")
+
+
+def fail(msg: str):
+    print(f"    ❌ {msg}")
+
+
+def warn(msg: str):
+    print(f"    ⚠️  {msg}")
+
+
+def git_pull() -> bool:
+    step("Pulling latest master onto HA instance...")
+    result = ssh("cd /homeassistant && git pull")
+    if result.returncode != 0:
+        fail(f"git pull failed:\n{result.stderr}")
+        return False
+    print(result.stdout.strip())
+    ok("Pull complete")
+    return True
+
+
+def check_config() -> bool:
+    step("Validating HA configuration (ha core check)...")
+    result = ssh("ha core check")
+    if result.returncode != 0:
+        fail("Config check FAILED — will not restart.")
+        print(result.stdout)
+        print(result.stderr)
+        print("\n    Fix the config error and run again.")
+        return False
+    ok("Config valid")
+    return True
+
+
+def restart_ha() -> bool:
+    step("Restarting HA core...")
+    result = ssh("ha core restart")
+    if result.returncode != 0:
+        fail(f"Restart command failed:\n{result.stderr}")
+        return False
+    ok("Restart command accepted — waiting for HA to come back online...")
+    return True
+
+
+def wait_for_ha() -> bool:
+    step(f"Polling HA for up to {RESTART_TIMEOUT}s...")
+    deadline = time.time() + RESTART_TIMEOUT
+    dots = 0
+    while time.time() < deadline:
+        result = ssh("ha core info 2>/dev/null | grep -c 'state: running'")
+        if result.returncode == 0 and result.stdout.strip() == "1":
+            ok(f"HA is back online")
+            return True
+        time.sleep(5)
+        dots += 1
+        print(f"    ...waiting ({dots * 5}s)", end="\r")
+
+    fail(f"HA did not come back within {RESTART_TIMEOUT}s.")
+    print("""
+    SSH is still available (SSH addon is separate from HA core).
+    To diagnose:
+        ssh root@homeassistant.local "ha core logs 2>/dev/null | tail -30"
+
+    To rollback last git commit and retry:
+        ssh root@homeassistant.local "cd /homeassistant && git revert HEAD --no-edit && ha core check && ha core restart"
+    """)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Deploy latest HA config safely")
+    parser.add_argument("--check-only", action="store_true", help="Validate config without restarting")
+    parser.add_argument("--restart-only", action="store_true", help="Skip git pull, just check+restart")
+    args = parser.parse_args()
+
+    print("=" * 55)
+    print("  ha-deploy: safe HA config deployment")
+    print("=" * 55)
+
+    if not args.restart_only:
+        if not git_pull():
+            sys.exit(1)
+
+    if not check_config():
+        sys.exit(1)
+
+    if args.check_only:
+        print("\n--check-only: skipping restart.")
+        sys.exit(0)
+
+    if not restart_ha():
+        sys.exit(1)
+
+    if not wait_for_ha():
+        sys.exit(1)
+
+    print("\n" + "=" * 55)
+    print("  ✅ Deploy complete — HA is running.")
+    print("=" * 55)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/ha-deploy/deploy.py
+++ b/.github/skills/ha-deploy/deploy.py
@@ -6,20 +6,28 @@ Usage:
     python .github/skills/ha-deploy/deploy.py
     python .github/skills/ha-deploy/deploy.py --check-only   # validate without restart
     python .github/skills/ha-deploy/deploy.py --restart-only # skip pull, just check+restart
+
+Environment overrides:
+    HA_HOST     SSH target (default: root@homeassistant.local)
+    HA_REPO_DIR Git repo path on HA instance (default: /homeassistant)
 """
 import subprocess
 import sys
 import time
 import argparse
+import os
 
-HA_HOST = "root@homeassistant.local"
+HA_HOST = os.environ.get("HA_HOST", "root@homeassistant.local")
+HA_REPO_DIR = os.environ.get("HA_REPO_DIR", "/homeassistant")
 RESTART_TIMEOUT = 120  # seconds to wait for HA to come back
 
+SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3"]
 
-def ssh(cmd: str, capture: bool = True) -> subprocess.CompletedProcess:
+
+def ssh(cmd: str) -> subprocess.CompletedProcess:
     return subprocess.run(
-        ["ssh", HA_HOST, cmd],
-        capture_output=capture,
+        ["ssh", *SSH_OPTS, HA_HOST, cmd],
+        capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
@@ -44,7 +52,17 @@ def warn(msg: str):
 
 def git_pull() -> bool:
     step("Pulling latest master onto HA instance...")
-    result = ssh("cd /homeassistant && git pull")
+    # Verify we're on master before pulling
+    branch = ssh(f"cd {HA_REPO_DIR} && git rev-parse --abbrev-ref HEAD")
+    current = branch.stdout.strip()
+    if current != "master":
+        warn(f"HA repo is on branch '{current}', not master — switching to master first")
+        result = ssh(f"cd {HA_REPO_DIR} && git checkout master")
+        if result.returncode != 0:
+            fail(f"Could not switch to master:\n{result.stderr}")
+            return False
+
+    result = ssh(f"cd {HA_REPO_DIR} && git pull origin master")
     if result.returncode != 0:
         fail(f"git pull failed:\n{result.stderr}")
         return False
@@ -83,29 +101,36 @@ def wait_for_ha() -> bool:
     while time.time() < deadline:
         result = ssh("ha core info 2>/dev/null | grep -c 'state: running'")
         if result.returncode == 0 and result.stdout.strip() == "1":
-            ok(f"HA is back online")
+            ok("HA is back online")
             return True
         time.sleep(5)
         dots += 1
         print(f"    ...waiting ({dots * 5}s)", end="\r")
 
     fail(f"HA did not come back within {RESTART_TIMEOUT}s.")
-    print("""
+    print(f"""
     SSH is still available (SSH addon is separate from HA core).
     To diagnose:
-        ssh root@homeassistant.local "ha core logs 2>/dev/null | tail -30"
+        ssh {HA_HOST} "ha core logs 2>/dev/null | tail -30"
 
-    To rollback last git commit and retry:
-        ssh root@homeassistant.local "cd /homeassistant && git revert HEAD --no-edit && ha core check && ha core restart"
+    To rollback to last known-good origin/master and retry:
+        ssh {HA_HOST} "cd {HA_REPO_DIR} && git fetch origin && git reset --hard origin/master && ha core check && ha core restart"
     """)
     return False
 
 
 def main():
+    global HA_HOST, HA_REPO_DIR
+
     parser = argparse.ArgumentParser(description="Deploy latest HA config safely")
     parser.add_argument("--check-only", action="store_true", help="Validate config without restarting")
     parser.add_argument("--restart-only", action="store_true", help="Skip git pull, just check+restart")
+    parser.add_argument("--host", default=HA_HOST, help=f"SSH target (default: {HA_HOST})")
+    parser.add_argument("--repo-dir", default=HA_REPO_DIR, help=f"Repo path on HA (default: {HA_REPO_DIR})")
     args = parser.parse_args()
+
+    HA_HOST = args.host
+    HA_REPO_DIR = args.repo_dir
 
     print("=" * 55)
     print("  ha-deploy: safe HA config deployment")

--- a/.github/skills/ha-investigate/SKILL.md
+++ b/.github/skills/ha-investigate/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: ha-investigate
+description: Read-only inspection of the live Home Assistant instance over SSH. Use this for checking HA status, logs, entities, config entries, Lovelace dashboards, and storage files. All operations are strictly read-only — no state is modified. Use this instead of raw SSH commands for any HA inspection task.
+---
+
+# ha-investigate: Safe HA Inspection
+
+Use this skill for any read-only inspection of the live HA instance. It wraps SSH commands in a safelisted script so a single invocation covers multiple reads without per-command approval prompts.
+
+**Never run raw SSH reads directly** — use this skill instead.
+
+## Commands
+
+```bash
+# HA core status + running addons
+python .github/skills/ha-investigate/investigate.py status
+
+# Logs (last 50 lines, or filtered)
+python .github/skills/ha-investigate/investigate.py logs
+python .github/skills/ha-investigate/investigate.py logs --filter influx --lines 20
+python .github/skills/ha-investigate/investigate.py logs --filter "ERROR|WARNING"
+
+# Entities (all, by config entry, or by domain)
+python .github/skills/ha-investigate/investigate.py entities
+python .github/skills/ha-investigate/investigate.py entities --config-entry 01KKYRH6NVQGV2WVY4AYPWFNNC
+python .github/skills/ha-investigate/investigate.py entities --domain sensor
+
+# Config entries (all integrations, or by domain)
+python .github/skills/ha-investigate/investigate.py config-entries
+python .github/skills/ha-investigate/investigate.py config-entries --domain influxdb
+
+# Lovelace dashboard view summary
+python .github/skills/ha-investigate/investigate.py lovelace
+python .github/skills/ha-investigate/investigate.py lovelace --dashboard lovelace
+
+# Read a .storage file (safelisted keys only)
+python .github/skills/ha-investigate/investigate.py storage core.entity_registry
+python .github/skills/ha-investigate/investigate.py storage lovelace.lovelace_domov
+
+# Read a config file from HA
+python .github/skills/ha-investigate/investigate.py file /homeassistant/configuration.yaml
+```
+
+## Safety
+
+- **Read-only**: no writes, no restarts, no state changes
+- **Safelisted paths**: `storage` command only accepts known `.storage/` keys; `file` command only allows paths under `/homeassistant/`, `/config/`, `/tmp/`
+- SSH is always available even if HA core is not running (SSH addon is a separate supervisor process)
+
+## When to use vs ha-deploy
+
+| Task | Skill |
+|------|-------|
+| Check logs, entities, status | `ha-investigate` |
+| Validate config | `ha-deploy --check-only` |
+| Pull + restart | `ha-deploy` |

--- a/.github/skills/ha-investigate/investigate.py
+++ b/.github/skills/ha-investigate/investigate.py
@@ -16,9 +16,12 @@ Usage:
 import subprocess
 import sys
 import argparse
-import json
+import os
+import re
+import shlex
 
-HA_HOST = "root@homeassistant.local"
+HA_HOST = os.environ.get("HA_HOST", "root@homeassistant.local")
+SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3"]
 
 # Safelist of .storage keys allowed to be read
 ALLOWED_STORAGE = {
@@ -34,17 +37,50 @@ ALLOWED_STORAGE = {
     "core.config_entries",
 }
 
-# Safelist of file paths allowed to be read from HA instance
+# Safelist of file path prefixes allowed to be read from HA instance
 ALLOWED_FILE_PREFIXES = (
     "/homeassistant/",
     "/config/",
     "/tmp/",
 )
 
+# Validation patterns
+_RE_CONFIG_ENTRY_ID = re.compile(r'^[A-Z0-9]{26}$')
+_RE_DOMAIN = re.compile(r'^[a-z][a-z0-9_]*$')
+
+
+def _validate_config_entry_id(value: str) -> str:
+    if not _RE_CONFIG_ENTRY_ID.match(value):
+        print(f"Error: invalid config entry ID '{value}' (expected 26 uppercase alphanumeric chars)", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _validate_domain(value: str) -> str:
+    if not _RE_DOMAIN.match(value):
+        print(f"Error: invalid domain '{value}' (expected lowercase letters, digits, underscores)", file=sys.stderr)
+        sys.exit(1)
+    return value
+
+
+def _validate_file_path(path: str) -> str:
+    """Normalize path, reject traversal, verify against safelist prefixes."""
+    normalized = os.path.normpath(path)
+    # Reject any path with remaining .. components after normalization
+    if ".." in normalized.split(os.sep):
+        print(f"Error: path traversal detected in '{path}'", file=sys.stderr)
+        sys.exit(1)
+    # normpath on Linux uses / separator; force it
+    normalized = normalized.replace("\\", "/")
+    if not any(normalized.startswith(p) for p in ALLOWED_FILE_PREFIXES):
+        print(f"Error: path '{normalized}' not under allowed prefixes: {ALLOWED_FILE_PREFIXES}", file=sys.stderr)
+        sys.exit(1)
+    return normalized
+
 
 def ssh(cmd: str) -> str:
     result = subprocess.run(
-        ["ssh", HA_HOST, cmd],
+        ["ssh", *SSH_OPTS, HA_HOST, cmd],
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -68,7 +104,9 @@ def cmd_logs(args):
     lines = getattr(args, "lines", 50)
     pattern = getattr(args, "filter", None)
     if pattern:
-        out = ssh(f"ha core logs 2>/dev/null | grep -i '{pattern}' | tail -{lines}")
+        # Use shlex.quote to safely pass the pattern to the remote shell
+        quoted_pattern = shlex.quote(pattern)
+        out = ssh(f"ha core logs 2>/dev/null | grep -i {quoted_pattern} | tail -{lines}")
     else:
         out = ssh(f"ha core logs 2>/dev/null | tail -{lines}")
     print(out)
@@ -80,13 +118,18 @@ def cmd_entities(args):
     domain = getattr(args, "domain", None)
 
     if config_entry:
-        jq_filter = f'.data.entities[] | select(.config_entry_id=="{config_entry}") | .entity_id'
+        _validate_config_entry_id(config_entry)
+        # Use jq --arg to avoid interpolating user input into the jq program
+        out = ssh(f"jq -r --arg id {shlex.quote(config_entry)} "
+                  f"'.data.entities[] | select(.config_entry_id==$id) | .entity_id' "
+                  f"/homeassistant/.storage/core.entity_registry 2>/dev/null | sort")
     elif domain:
-        jq_filter = f'.data.entities[] | select(.entity_id | startswith("{domain}.")) | .entity_id'
+        _validate_domain(domain)
+        out = ssh(f"jq -r --arg prefix {shlex.quote(domain + '.')} "
+                  f"'.data.entities[] | select(.entity_id | startswith($prefix)) | .entity_id' "
+                  f"/homeassistant/.storage/core.entity_registry 2>/dev/null | sort")
     else:
-        jq_filter = ".data.entities[] | .entity_id"
-
-    out = ssh(f"jq -r '{jq_filter}' /homeassistant/.storage/core.entity_registry 2>/dev/null | sort")
+        out = ssh("jq -r '.data.entities[] | .entity_id' /homeassistant/.storage/core.entity_registry 2>/dev/null | sort")
     print(out)
 
 
@@ -94,21 +137,25 @@ def cmd_config_entries(args):
     """List config entries, optionally filtered by domain."""
     domain = getattr(args, "domain", None)
     if domain:
-        jq_filter = f'.data.entries[] | select(.domain=="{domain}") | {{domain, title, state, source}}'
+        _validate_domain(domain)
+        out = ssh(f"jq --arg domain {shlex.quote(domain)} "
+                  f"'.data.entries[] | select(.domain==$domain) | {{domain, title, state, source}}' "
+                  f"/homeassistant/.storage/core.config_entries 2>/dev/null")
     else:
-        jq_filter = '.data.entries[] | {domain, title, state}'
-    out = ssh(f"jq '{jq_filter}' /homeassistant/.storage/core.config_entries 2>/dev/null")
+        out = ssh("jq '.data.entries[] | {domain, title, state}' /homeassistant/.storage/core.config_entries 2>/dev/null")
     print(out)
 
 
 def cmd_lovelace(args):
-    """Dump Lovelace dashboard config."""
+    """Show Lovelace dashboard view summary."""
     dashboard = getattr(args, "dashboard", None) or "lovelace_domov"
-    key = f"lovelace.{dashboard}" if not dashboard.startswith("lovelace") else dashboard
+    key = f"lovelace.{dashboard}" if not dashboard.startswith("lovelace.") else dashboard
     if key not in ALLOWED_STORAGE:
         print(f"Error: '{key}' not in allowed storage safelist: {sorted(ALLOWED_STORAGE)}", file=sys.stderr)
         sys.exit(1)
-    out = ssh(f"jq '.data.config.views | to_entries | .[] | {{index: .key, path: .value.path, title: .value.title, icon: .value.icon, cards: (.value.cards | length)}}' /homeassistant/.storage/{key} 2>/dev/null")
+    out = ssh(f"jq '.data.config.views | to_entries | .[] | "
+              f"{{index: .key, path: .value.path, title: .value.title, icon: .value.icon, cards: (.value.cards | length)}}' "
+              f"/homeassistant/.storage/{key} 2>/dev/null")
     print(out)
 
 
@@ -125,11 +172,8 @@ def cmd_storage(args):
 
 def cmd_file(args):
     """Read a file from the HA instance (safelisted path prefixes only)."""
-    path = args.path
-    if not any(path.startswith(p) for p in ALLOWED_FILE_PREFIXES):
-        print(f"Error: path '{path}' not under allowed prefixes: {ALLOWED_FILE_PREFIXES}", file=sys.stderr)
-        sys.exit(1)
-    out = ssh(f"cat '{path}' 2>/dev/null")
+    path = _validate_file_path(args.path)
+    out = ssh(f"cat {shlex.quote(path)} 2>/dev/null")
     print(out)
 
 
@@ -144,14 +188,14 @@ def main():
     p_logs.add_argument("--lines", type=int, default=50, help="Number of lines (default: 50)")
 
     p_ent = sub.add_parser("entities", help="List entities")
-    p_ent.add_argument("--config-entry", metavar="ID", help="Filter by config entry ID")
+    p_ent.add_argument("--config-entry", metavar="ID", help="Filter by config entry ID (26-char alphanumeric)")
     p_ent.add_argument("--domain", help="Filter by domain (e.g. sensor, binary_sensor)")
 
     p_ce = sub.add_parser("config-entries", help="List config entries")
     p_ce.add_argument("--domain", help="Filter by integration domain")
 
     p_lv = sub.add_parser("lovelace", help="Show Lovelace dashboard view summary")
-    p_lv.add_argument("--dashboard", default="lovelace_domov", help="Dashboard storage key suffix")
+    p_lv.add_argument("--dashboard", default="lovelace_domov", help="Dashboard name (default: lovelace_domov)")
 
     p_st = sub.add_parser("storage", help="Read a .storage file (safelisted)")
     p_st.add_argument("key", help=f"Storage key. Allowed: {sorted(ALLOWED_STORAGE)}")

--- a/.github/skills/ha-investigate/investigate.py
+++ b/.github/skills/ha-investigate/investigate.py
@@ -21,7 +21,7 @@ import re
 import shlex
 
 HA_HOST = os.environ.get("HA_HOST", "root@homeassistant.local")
-SSH_OPTS = ["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3"]
+SSH_OPTS = ["-o", "ConnectTimeout=10", "-o", "ServerAliveInterval=15", "-o", "ServerAliveCountMax=3"]
 
 # Safelist of .storage keys allowed to be read
 ALLOWED_STORAGE = {

--- a/.github/skills/ha-investigate/investigate.py
+++ b/.github/skills/ha-investigate/investigate.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+ha-investigate: Safe read-only inspection of the live HA instance over SSH.
+
+All commands are strictly read-only. No state is modified.
+
+Usage:
+    python .github/skills/ha-investigate/investigate.py status
+    python .github/skills/ha-investigate/investigate.py logs [--filter PATTERN] [--lines N]
+    python .github/skills/ha-investigate/investigate.py entities [--config-entry ID] [--domain DOMAIN]
+    python .github/skills/ha-investigate/investigate.py config-entries [--domain DOMAIN]
+    python .github/skills/ha-investigate/investigate.py lovelace [--dashboard NAME]
+    python .github/skills/ha-investigate/investigate.py storage STORAGE_KEY
+    python .github/skills/ha-investigate/investigate.py file PATH
+"""
+import subprocess
+import sys
+import argparse
+import json
+
+HA_HOST = "root@homeassistant.local"
+
+# Safelist of .storage keys allowed to be read
+ALLOWED_STORAGE = {
+    "lovelace.lovelace_domov",
+    "lovelace.lovelace",
+    "lovelace.map",
+    "lovelace.dashboard_location",
+    "lovelace_dashboards",
+    "lovelace_resources",
+    "core.entity_registry",
+    "core.device_registry",
+    "core.area_registry",
+    "core.config_entries",
+}
+
+# Safelist of file paths allowed to be read from HA instance
+ALLOWED_FILE_PREFIXES = (
+    "/homeassistant/",
+    "/config/",
+    "/tmp/",
+)
+
+
+def ssh(cmd: str) -> str:
+    result = subprocess.run(
+        ["ssh", HA_HOST, cmd],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if result.returncode != 0 and result.stderr:
+        print(f"[ssh stderr] {result.stderr.strip()}", file=sys.stderr)
+    return result.stdout
+
+
+def cmd_status(args):
+    """HA core status, version, and addon overview."""
+    print("=== HA Core Info ===")
+    print(ssh("ha core info 2>/dev/null"))
+    print("=== Running Addons ===")
+    print(ssh("ha addons list 2>/dev/null | grep -E 'name:|state:' | paste - -"))
+
+
+def cmd_logs(args):
+    """HA core logs, optionally filtered."""
+    lines = getattr(args, "lines", 50)
+    pattern = getattr(args, "filter", None)
+    if pattern:
+        out = ssh(f"ha core logs 2>/dev/null | grep -i '{pattern}' | tail -{lines}")
+    else:
+        out = ssh(f"ha core logs 2>/dev/null | tail -{lines}")
+    print(out)
+
+
+def cmd_entities(args):
+    """List entities, optionally filtered by config entry ID or domain."""
+    config_entry = getattr(args, "config_entry", None)
+    domain = getattr(args, "domain", None)
+
+    if config_entry:
+        jq_filter = f'.data.entities[] | select(.config_entry_id=="{config_entry}") | .entity_id'
+    elif domain:
+        jq_filter = f'.data.entities[] | select(.entity_id | startswith("{domain}.")) | .entity_id'
+    else:
+        jq_filter = ".data.entities[] | .entity_id"
+
+    out = ssh(f"jq -r '{jq_filter}' /homeassistant/.storage/core.entity_registry 2>/dev/null | sort")
+    print(out)
+
+
+def cmd_config_entries(args):
+    """List config entries, optionally filtered by domain."""
+    domain = getattr(args, "domain", None)
+    if domain:
+        jq_filter = f'.data.entries[] | select(.domain=="{domain}") | {{domain, title, state, source}}'
+    else:
+        jq_filter = '.data.entries[] | {domain, title, state}'
+    out = ssh(f"jq '{jq_filter}' /homeassistant/.storage/core.config_entries 2>/dev/null")
+    print(out)
+
+
+def cmd_lovelace(args):
+    """Dump Lovelace dashboard config."""
+    dashboard = getattr(args, "dashboard", None) or "lovelace_domov"
+    key = f"lovelace.{dashboard}" if not dashboard.startswith("lovelace") else dashboard
+    if key not in ALLOWED_STORAGE:
+        print(f"Error: '{key}' not in allowed storage safelist: {sorted(ALLOWED_STORAGE)}", file=sys.stderr)
+        sys.exit(1)
+    out = ssh(f"jq '.data.config.views | to_entries | .[] | {{index: .key, path: .value.path, title: .value.title, icon: .value.icon, cards: (.value.cards | length)}}' /homeassistant/.storage/{key} 2>/dev/null")
+    print(out)
+
+
+def cmd_storage(args):
+    """Read a .storage file (safelisted keys only)."""
+    key = args.key
+    if key not in ALLOWED_STORAGE:
+        print(f"Error: '{key}' not in allowed storage safelist.", file=sys.stderr)
+        print(f"Allowed: {sorted(ALLOWED_STORAGE)}", file=sys.stderr)
+        sys.exit(1)
+    out = ssh(f"cat /homeassistant/.storage/{key} 2>/dev/null")
+    print(out)
+
+
+def cmd_file(args):
+    """Read a file from the HA instance (safelisted path prefixes only)."""
+    path = args.path
+    if not any(path.startswith(p) for p in ALLOWED_FILE_PREFIXES):
+        print(f"Error: path '{path}' not under allowed prefixes: {ALLOWED_FILE_PREFIXES}", file=sys.stderr)
+        sys.exit(1)
+    out = ssh(f"cat '{path}' 2>/dev/null")
+    print(out)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read-only HA instance inspection")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("status", help="HA core status and addon overview")
+
+    p_logs = sub.add_parser("logs", help="HA core logs")
+    p_logs.add_argument("--filter", metavar="PATTERN", help="grep filter pattern")
+    p_logs.add_argument("--lines", type=int, default=50, help="Number of lines (default: 50)")
+
+    p_ent = sub.add_parser("entities", help="List entities")
+    p_ent.add_argument("--config-entry", metavar="ID", help="Filter by config entry ID")
+    p_ent.add_argument("--domain", help="Filter by domain (e.g. sensor, binary_sensor)")
+
+    p_ce = sub.add_parser("config-entries", help="List config entries")
+    p_ce.add_argument("--domain", help="Filter by integration domain")
+
+    p_lv = sub.add_parser("lovelace", help="Show Lovelace dashboard view summary")
+    p_lv.add_argument("--dashboard", default="lovelace_domov", help="Dashboard storage key suffix")
+
+    p_st = sub.add_parser("storage", help="Read a .storage file (safelisted)")
+    p_st.add_argument("key", help=f"Storage key. Allowed: {sorted(ALLOWED_STORAGE)}")
+
+    p_fi = sub.add_parser("file", help="Read a file from HA instance (safelisted paths)")
+    p_fi.add_argument("path", help="Absolute path on HA instance")
+
+    args = parser.parse_args()
+    {
+        "status": cmd_status,
+        "logs": cmd_logs,
+        "entities": cmd_entities,
+        "config-entries": cmd_config_entries,
+        "lovelace": cmd_lovelace,
+        "storage": cmd_storage,
+        "file": cmd_file,
+    }[args.command](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/copilot-permissions-wishlist.md
+++ b/docs/copilot-permissions-wishlist.md
@@ -1,0 +1,75 @@
+# Copilot CLI Permissions Wishlist
+
+Desired auto-approval configuration once the Copilot CLI adds persistent tool permissions.
+Track progress at: https://github.com/github/copilot-cli/issues/307 (Phase 4, ~Q2 2026)
+Related: https://github.com/github/copilot-cli/issues/1973
+
+## Currently in config.json (working for git/gh, ignored for the rest until feature lands)
+
+See `~/.copilot/config.json`.
+
+## Desired: argument-level shell() patterns
+
+These require argument-level matching which doesn't exist yet
+(current `shell()` matches command name only, not arguments).
+
+```json
+{
+  "allowed_tools": [
+    "shell(git commit)",
+    "shell(git checkout)",
+    "shell(git branch)",
+    "shell(git add)",
+    "shell(git fetch)",
+    "shell(git pull)",
+    "shell(git log)",
+    "shell(git diff)",
+    "shell(git status)",
+    "shell(git stash)",
+    "shell(git merge)",
+    "shell(git rebase)",
+    "shell(gh pr create)",
+    "shell(gh pr view)",
+    "shell(gh pr list)",
+    "shell(gh pr merge)",
+    "shell(gh issue create)",
+    "shell(gh issue comment)",
+    "shell(gh issue reopen)",
+    "shell(gh issue view)",
+    "shell(gh issue list)",
+    "shell(python .github/skills/ha-deploy/deploy.py:*)",
+    "shell(python .github/skills/ha-investigate/investigate.py:*)"
+  ],
+  "denied_tools": [
+    "shell(git push --force)",
+    "shell(git push --force-with-lease)",
+    "shell(git push --delete)",
+    "shell(git push origin :*)",
+    "shell(git reset --hard)",
+    "shell(git commit --amend)",
+    "shell(git branch -D)",
+    "shell(git filter-branch)",
+    "shell(gh issue close)",
+    "shell(ssh:*)"
+  ]
+}
+```
+
+## Why not `shell(python)` broadly
+
+`shell(python)` auto-approves ANY python script — too broad.
+We only want to approve the specific skill scripts. Once argument-level
+matching lands, the `python .github/skills/...` patterns above are the
+right scope.
+
+## Why `shell(ssh:*)` is denied
+
+SSH commands vary from safe reads to destructive restarts — can't be
+distinguished at command-name level. Use `ha-investigate` and `ha-deploy`
+skills instead; approve those specific script invocations.
+
+## Current workaround
+
+The `git:*` and `gh` patterns in `config.json` already work (subcommand-level
+matching is supported). Python/SSH skills require manual approval per session
+until argument-level matching is implemented.


### PR DESCRIPTION
Documents the mandatory deploy sequence for applying PRs to the HA instance. Fixes two bugs in the existing instructions: wrong path (/config -> /homeassistant) and missing validation step. Copilot will now always run ha core check before ha core restart.