### PR TITLE
feat: add soundbar to morning radio automation

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -685,9 +685,15 @@
       entity_id: f24e24c6be67eedf11915c554bd13048
       type: is_playing
   actions:
+  - action: media_player.volume_set
+    data:
+      volume_level: 0.15
+    target:
+      entity_id: media_player.living_room_soundbar
+    continue_on_error: true
   - action: media_player.play_media
     target:
-      entity_id: media_player.living_room_speaker
+      entity_id: media_player.living_room_soundbar
     data:
       media_content_id: media-source://radio_browser/1b568695-9ce7-493d-ba72-d9b3d5e0a364
       media_content_type: audio/mpeg
@@ -695,19 +701,39 @@
       title: Evropa 2 - Radio
       thumbnail: https://m.actve.net/e2/favicon/apple-touch-icon.png
       media_class: music
-      children_media_class:
-      navigateIds:
-      - {}
-      - media_content_type: app
-        media_content_id: media-source://radio_browser
-      - media_content_type: music
-        media_content_id: media-source://radio_browser/country/CZ
-  - action: media_player.volume_set
-    metadata: {}
-    data:
-      volume_level: 0.3
-    target:
-      device_id: 55783b7df92e11eabf886bf57f72e81e
+    continue_on_error: true
+  - wait_template: "{{ is_state('media_player.living_room_soundbar', 'playing') }}"
+    timeout: "00:00:15"
+    continue_on_timeout: true
+  - if:
+    - condition: not
+      conditions:
+      - condition: state
+        entity_id: media_player.living_room_soundbar
+        state: playing
+    then:
+    - action: media_player.volume_set
+      data:
+        volume_level: 0.3
+      target:
+        device_id: 55783b7df92e11eabf886bf57f72e81e
+    - action: media_player.play_media
+      target:
+        entity_id: media_player.living_room_speaker
+      data:
+        media_content_id: media-source://radio_browser/1b568695-9ce7-493d-ba72-d9b3d5e0a364
+        media_content_type: audio/mpeg
+      metadata:
+        title: Evropa 2 - Radio
+        thumbnail: https://m.actve.net/e2/favicon/apple-touch-icon.png
+        media_class: music
+        children_media_class:
+        navigateIds:
+        - {}
+        - media_content_type: app
+          media_content_id: media-source://radio_browser
+        - media_content_type: music
+          media_content_id: media-source://radio_browser/country/CZ
   mode: single
 - id: '1734246047036'
   alias: Car integration unavailable


### PR DESCRIPTION
Play Evropa 2 radio on the Samsung Q930C soundbar via Music Assistant AirPlay at 15% volume. Falls back to Google Home Mini at 30% if soundbar is not playing (e.g. AirPlay fails).

## Changes
- Soundbar (via AirPlay/Music Assistant) is the primary radio target
- Volume set to 15% (soundbar is much louder than the Mini)
- If soundbar fails to play, falls back to Google Mini at original 30%
- Uses \continue_on_error: true\ so AirPlay failures don't block the fallback

## Dependencies
- Music Assistant add-on installed and running on HA
- Soundbar discovered as \media_player.living_room_soundbar\ via AirPlay