### PR TITLE
fix: increase soundbar volume to 30%

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -687,7 +687,7 @@
   actions:
   - action: media_player.volume_set
     data:
-      volume_level: 0.15
+      volume_level: 0.3
     target:
       entity_id: media_player.living_room_soundbar
     continue_on_error: true


### PR DESCRIPTION
AirPlay 2 confirmed working on Samsung Q930C soundbar via Music Assistant. Volume at 15% was too quiet — bumping to 30% to match the Google Mini fallback level.