### PR TITLE
fix: disable samsung_soundbar custom component (broken on HA 2026.3)

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -35,12 +35,14 @@ zha:
       sonoff_provider: true
       thirdreality_provider: false
 
-samsung_soundbar:
-  devices:
-    - name: Living room soundbar
-      api_key: !secret living_room_soundbar_api_key
-      device_id: !secret living_room_soundbar_device_id
-      max_volume: 100
+# samsung_soundbar: disabled temporarily — broken on HA 2026.3 (SUPPORT_PAUSE removed)
+# TODO: fix media_player.py or wait for upstream update
+# samsung_soundbar:
+#   devices:
+#     - name: Living room soundbar
+#       api_key: !secret living_room_soundbar_api_key
+#       device_id: !secret living_room_soundbar_device_id
+#       max_volume: 100
 
 api:
 


### PR DESCRIPTION
The samsung_soundbar HACS custom component fails on every boot with:

\\\
Unable to prepare setup for platform 'samsung_soundbar.media_player': Platform not found
(cannot import name 'SUPPORT_PAUSE' from 'homeassistant.components.media_player.const')
\\\

This causes a blocking import in the event loop, contributing to stability issues. Commented out in configuration.yaml until upstream fixes or we patch locally.

See issue logged for the fix.