### PR TITLE
chore: gitignore service account tokens for Copilot tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,10 @@ hass-emulated-hue
 .ha_run.lock
 .ha_token
 
+# Service account tokens for Copilot / tooling (read-only)
+.influxdb_reader_token
+.grafana_token
+
 # Cached integration brand icons and metadata (auto-downloaded by HA)
 .cache/
 


### PR DESCRIPTION
Adds read-only service account token files to .gitignore:

- **\.influxdb_reader_token\** — InfluxDB \copilot\ user (READ-only on \homeassistant\ + \glances\ DBs)
- **\.grafana_token\** — Grafana Viewer service account API token

These are stored on the HA instance alongside the existing \.ha_token\ and allow Copilot to safely query InfluxDB and Grafana without using the write-capable \homeassistant\ credentials.

Part of the credential hygiene cleanup after the InfluxDB password rotation.