### PR TITLE
fix: replace broken samsung_soundbar with YASSI integration

### DIFF
--- a/.github/workflows/home-assistant.yml
+++ b/.github/workflows/home-assistant.yml
@@ -23,13 +23,6 @@ jobs:
       - name: Check out configuration from GitHub
         uses: actions/checkout@v4
 
-      - name: Stub custom integrations for CI
-        run: |
-          mkdir -p custom_components/samsung_soundbar
-          echo '{"domain":"samsung_soundbar","name":"Samsung Soundbar (stub)","version":"0.0.0","integration_type":"device"}' \
-            > custom_components/samsung_soundbar/manifest.json
-          touch custom_components/samsung_soundbar/__init__.py
-
       - name: Upload prepared config
         uses: actions/upload-artifact@v4
         with:

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -35,15 +35,6 @@ zha:
       sonoff_provider: true
       thirdreality_provider: false
 
-# samsung_soundbar: disabled temporarily — broken on HA 2026.3 (SUPPORT_PAUSE removed)
-# TODO: fix media_player.py or wait for upstream update
-# samsung_soundbar:
-#   devices:
-#     - name: Living room soundbar
-#       api_key: !secret living_room_soundbar_api_key
-#       device_id: !secret living_room_soundbar_device_id
-#       max_volume: 100
-
 api:
 
 # zha_toolkit is now enabled through HACS custom components

--- a/secrets.fake.yaml
+++ b/secrets.fake.yaml
@@ -4,5 +4,4 @@
 #
 # If you add a !secret reference anywhere in the config,
 # add a matching dummy entry here so CI continues to pass.
-living_room_soundbar_api_key: fake_api_key
-living_room_soundbar_device_id: fake_device_id
+


### PR DESCRIPTION
Closes #23

## Problem

The \samsung_soundbar\ HACS custom component ([thierryBourbon/Home-Assistant-Samsung-Soundbar](https://github.com/thierryBourbon/Home-Assistant-Samsung-Soundbar)) is broken on HA 2026.3+ due to removed \SUPPORT_*\ constants. The upstream repo is abandoned (last commit June 2023, 13 open issues, 0 PRs).

## Solution

Replace with [**YASSI**](https://github.com/samuelspagl/ha_samsung_soundbar) (\samuelspagl/ha_samsung_soundbar\) — an actively maintained Samsung soundbar integration that:
- Uses modern \MediaPlayerEntityFeature\ enum (HA 2026.3 compatible)
- Config flow (UI-based setup, no YAML needed)
- More features: select, number, sensor, and switch entities
- Last updated March 2026, 78+ stars

## Repo Changes

- Remove commented-out \samsung_soundbar\ YAML config from \configuration.yaml\
- Remove CI stub for \samsung_soundbar\ custom component
- Remove unused soundbar fake secrets from \secrets.fake.yaml\

## HA-Side Migration Steps (after merge + deploy)

1. **Remove old component** via HACS: HACS → Integrations → Samsung Soundbar → Remove
2. **Add YASSI as custom repo** in HACS: HACS → ⋮ menu → Custom repositories → paste \https://github.com/samuelspagl/ha_samsung_soundbar\ → Category: Integration
3. **Install YASSI**: Search \samsung soundbar\ in HACS → Install
4. **Restart HA**
5. **Configure via UI**: Settings → Devices & Services → Add Integration → Samsung Soundbar → enter SmartThings API key + device ID
6. **Clean up \secrets.yaml\**: remove \living_room_soundbar_api_key\ and \living_room_soundbar_device_id\ (YASSI stores credentials in config entries, not YAML)