### PR TITLE
feat: make location dashboard admin-only

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -52,6 +52,7 @@ lovelace:
       title: Location
       icon: mdi:map-marker
       show_in_sidebar: true
+      require_admin: true
 
 zha:
   zigpy_config:


### PR DESCRIPTION
Adds require_admin: true to the yaml-location dashboard so only admin users see it in the sidebar.