### PR TITLE
Add Kids room main light to kids dashboard

### DIFF
--- a/lovelace-domov.yaml
+++ b/lovelace-domov.yaml
@@ -208,6 +208,7 @@ views:
     cards:
       - type: entities
         entities:
+          - light.kids_room_main_light
           - light.kids_room_olivers_bed_light_light
           - light.kids_room_table_light_light
       - type: entities


### PR DESCRIPTION
Adds the newly paired Eglo/AwoX bulb (light.kids_room_main_light) to the kids-room view - first entity in the lights entities card.

Device: AwoX EZMB-RGB-TW-CLB, paired via ZHA. yamllint passes with no new warnings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>